### PR TITLE
Update and rename Merging_vs_Rebasing.md to git_merging_vs_rebasing.md

### DIFF
--- a/git_merging_vs_rebasing.md
+++ b/git_merging_vs_rebasing.md
@@ -1,4 +1,4 @@
-#Merging vs Rebasing
+Merging vs Rebasing
 
 **Summary:**
 


### PR DESCRIPTION
issue fixed: #18 removed '#' from heading